### PR TITLE
Fix recorder interference

### DIFF
--- a/ios/Classes/StereoPlugin.m
+++ b/ios/Classes/StereoPlugin.m
@@ -35,9 +35,8 @@
 #pragma mark - UIApplicationDelegate methods
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
-    // Begin audio session.
-    // [self _beginAudioSession];
 
+    // Don't begin audio session until we need it so that it doesn't interfere with recording
     return YES;
 }
 
@@ -169,9 +168,9 @@
 
     if (_player == nil) {
       [self _beginAudioSession];
+    } else {
+      [self _pause];
     }
-
-    [self _pause];
 
     AVAsset *asset = [AVAsset assetWithURL:url];
     NSArray *assetKeys = @[@"playable", @"hasProtectedContent"];
@@ -278,6 +277,8 @@
     [_channel invokeMethod:@"platform.position" arguments:@(0)];
     
     _isPlaying = false;
+
+    [self _endAudioSession];
 }
 
 - (void)_showMediaPlayerAlert {

--- a/ios/Classes/StereoPlugin.m
+++ b/ios/Classes/StereoPlugin.m
@@ -36,7 +36,7 @@
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
     // Begin audio session.
-    [self _beginAudioSession];
+    // [self _beginAudioSession];
 
     return YES;
 }
@@ -166,6 +166,11 @@
 }
 
 - (int)_loadItemWithURL:(NSURL * _Nonnull)url {
+
+    if (_player == nil) {
+      [self _beginAudioSession];
+    }
+
     [self _pause];
 
     AVAsset *asset = [AVAsset assetWithURL:url];


### PR DESCRIPTION
Because the stereo library initiates a playback session on loading of the application, apps that want to use this with a recording library will fail on a physical iPhone. See https://stackoverflow.com/questions/50687163/how-can-i-track-down-interference-between-the-flutter-libraries-audo-recorder-an

This change defers the initiating of the audio playback session until it is needed so that it doesn't interfere when another library needs to initiate an audio recording session.